### PR TITLE
Multi cam implementation + Path management fixes.

### DIFF
--- a/External Renderer/Assets/Editor/ImportGUI.cs
+++ b/External Renderer/Assets/Editor/ImportGUI.cs
@@ -6,16 +6,32 @@ namespace ExternalUnityRendering.UnityEditor
     [CustomEditor(typeof(ImportScene))]
     class ImportGUI : Editor
     {
+        private string _importFile = "";
+        private string _renderFolder = "";
+        // HACK very janky
         public override void OnInspectorGUI()
         {
             DrawDefaultInspector();
-
-            EditorGUILayout.HelpBox("Click Import Now to Import now.", MessageType.None);
-
+            EditorGUILayout.HelpBox("Enter path to import json below.", MessageType.None);
+            _importFile = GUILayout.TextField(_importFile);
+            EditorGUILayout.HelpBox("Enter path to render images to below.", MessageType.None);
+            _renderFolder = GUILayout.TextField(_renderFolder);
             ImportScene currentImporter = target as ImportScene;
             if (GUILayout.Button("Import Now"))
             {
-                currentImporter.ImportCurrentScene();
+                currentImporter.RenderFolder = _renderFolder;
+                PathManagement.FileManager import = new PathManagement.FileManager(_importFile);
+
+                if (import.Path == null)
+                {
+                    Debug.LogError("Invalid import path given.");
+                } else if (currentImporter.RenderFolder == Application.persistentDataPath)
+                {
+                    Debug.LogError("Invalid render folder given.");
+                } else
+                {
+                    currentImporter.ImportCurrentScene(import);
+                }
             }
         }
     }

--- a/External Renderer/Assets/Editor/TestingScript.cs
+++ b/External Renderer/Assets/Editor/TestingScript.cs
@@ -11,23 +11,27 @@ namespace ExternalUnityRendering.UnityEditor
         [MenuItem("Testing/Import+Images")]
         public static void TestImports()
         {
-            CustomCamera cam = FindObjectOfType<CustomCamera>();
-            cam.StartCoroutine(ImportMany());
+            Debug.LogWarning("This function is incomplete. It will do nothing.");
+            return;
+            // TODO properly implement testing
         }
 
+        // NOTE: this currently does not import.
         static IEnumerator ImportMany()
         {
             GameObject obj = new GameObject();
             ImportScene import = obj.AddComponent<ImportScene>();
 
-            import.RenderFolder = @"D:\Virtana\Planning\Import";
-            // TODO make sure this is legit somehow first instead of logging a bunch
-            // and doing nothing
-            // TODO ensure this is safe.
-            for (int i = 0; i < Runs; i++)
+            // TODO add in folder choice here
+            import.RenderFolder = @"D:\Virtana\Planning\Import"; 
+
+            // TODO add a way of importing paths correctly
+            string[] paths = { };
+
+            //for (int i = 0; i < Runs; i++)
+            foreach (string path in paths)
             {
-                import.ImportFilePath = string.Format(@"D:\Virtana\Planning\Scene State ({0}).json", i + 1);
-                import.ImportCurrentScene();
+                import.ImportCurrentScene(new PathManagement.FileManager(path));
                 yield return new WaitForSecondsRealtime(1f);
             }
         }

--- a/External Renderer/Assets/Scenes/Main.unity
+++ b/External Renderer/Assets/Scenes/Main.unity
@@ -757,6 +757,80 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1139120280
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1139120283}
+  - component: {fileID: 1139120282}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &1139120282
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1139120280}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1139120283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1139120280}
+  m_LocalRotation: {x: 0, y: -0.96280265, z: 0, w: 0.27020556}
+  m_LocalPosition: {x: 2.4, y: 0.65, z: 3.07}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: -148.647, z: 0}
 --- !u!1 &1241782539
 GameObject:
   m_ObjectHideFlags: 0
@@ -847,7 +921,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1 &1250538404
 GameObject:
@@ -1051,7 +1125,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1788036832}
   - component: {fileID: 1788036831}
-  - component: {fileID: 1788036830}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1059,14 +1132,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!81 &1788036830
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1788036829}
-  m_Enabled: 1
 --- !u!20 &1788036831
 Camera:
   m_ObjectHideFlags: 0
@@ -1161,7 +1226,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8252001624201780488, guid: 88de24aa742652f4d91ab7f17086eae4, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8252001624201780488, guid: 88de24aa742652f4d91ab7f17086eae4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/External Renderer/Assets/Scripts/Camera/CustomCamera.cs
+++ b/External Renderer/Assets/Scripts/Camera/CustomCamera.cs
@@ -28,13 +28,17 @@ namespace ExternalUnityRendering.CameraUtilites
             }
             set
             {
-                _renderPath = new DirectoryManager(value);
+                // TODO name all cameras according to heirarchy
+                // HACK cant tell apart cameras yet, so just let them all write to the same folder
+                _renderPath = new DirectoryManager($@"{ value }\Renders\{ this.name }");
             }
         }
 
-        private void Start()
+        private void Awake()
         {
-            _renderPath = new DirectoryManager();
+            // TODO add name parent concatenation for all cameras
+            // create a new camera directory in the subdirectory renders
+            _renderPath = new DirectoryManager($@"Renders\{ this.name }", true);
         }
 
         private void OnEnable()
@@ -46,6 +50,8 @@ namespace ExternalUnityRendering.CameraUtilites
             }
         }
 
+        // TODO Remove this and just directly call getcomponent CustomCamera is 
+        // automatically added to objects with cameras so check should not be needed
         /// <summary>
         /// Create an internal reference to the Camera component attached to
         /// this Gameobject. 
@@ -61,14 +67,16 @@ namespace ExternalUnityRendering.CameraUtilites
         }
 
         /// <summary>
-        /// Write the image in <paramref name="render"/> to the render path.
+        /// Write the image in <paramref name="render"/> to the render folder.
         /// </summary>
         /// <param name="data">Bytes of the image to be saved.</param>
         private void SaveRender(byte[] render)
         {
             FileManager file = new FileManager(_renderPath,
-                $"Render-{ DateTime.Now:yyyy-MM-dd-HH-mm-ss-fff-UTCzz}.png");
-            file.WriteToFile(render);
+                $"Render-{ DateTime.Now:yyyy-MM-dd-HH-mm-ss-fff-UTCzz}.png", true);
+
+            // will automatically rename if name collision occurs
+            file.WriteToFile(render); 
             Debug.Log($"Saved render to { file.Path } at { DateTime.Now }.");
         }
 
@@ -78,6 +86,8 @@ namespace ExternalUnityRendering.CameraUtilites
         /// <param name="renderSize">The resolution of the rendered image.</param>
         public void RenderImage(Vector2Int renderSize = default)
         {
+            // TODO maybe figure out a way to not have crazy high values that will trigger a 
+            // out of vram error
             // ensure screenshot size is at least 300x300 in size.
             renderSize.Clamp(
                 new Vector2Int(300, 300),
@@ -110,6 +120,8 @@ namespace ExternalUnityRendering.CameraUtilites
             SaveRender(png);
         }
 
+        // TODO determine the need for this. Physics exports multiple states and
+        // importer renders on each state. Exporter probably should have this functionality.
         /// <summary>
         /// Coroutine that renders an image every 
         /// [<paramref name="delay"/>] seconds.
@@ -126,6 +138,7 @@ namespace ExternalUnityRendering.CameraUtilites
             }
         }
 
+        // TODO same as above
         /// <summary>
         /// Render the view of the camera repeatedly.
         /// </summary>
@@ -138,9 +151,9 @@ namespace ExternalUnityRendering.CameraUtilites
                 StartCoroutine(RendererCoroutine(renderSize, delay));
         }
 
+        // TODO same as above
         /// <summary>
-        /// Stop rendering the view of the camera if StartIntervalRendering 
-        /// was called.
+        /// Stop rendering the view of the camera if StartIntervalRendering was called.
         /// </summary>
         public void StopIntervalRendering()
         {
@@ -154,25 +167,31 @@ namespace ExternalUnityRendering.CameraUtilites
             }
         }
 
-        // TODO Add multicam support.
         /// <summary>
-        /// On runtime load, attach the customCamera to the first gameobject
-        /// found with a camera component.
+        /// When the runtime loads, add a CustomCamera component to all camera 
+        /// gameobjects that don't already have it.
         /// </summary>
-        [RuntimeInitializeOnLoadMethod]
-        public static void AttachToCamera()
+        [Obsolete("Importer will handle attaching if necessary", true)]
+        //[RuntimeInitializeOnLoadMethod]
+        public static void AttachToCameras()
         {
-            Camera cam = FindObjectOfType<Camera>();
+            Camera[] cameras = FindObjectsOfType<Camera>();
 
-            if (cam != null)
+            if (cameras.Length == 0)
             {
-                // add this behaviour
-                cam.gameObject.AddComponent<CustomCamera>();
+                // If cam is empty, then no cameras were found.
+                Debug.LogError("Missing Camera! Importer cannot render from this.");
                 return;
             }
 
-            // If cam is null, then no cameras were found.
-            Debug.LogError("Missing Camera!");
+            foreach (Camera camera in cameras)
+            {
+                // add this behaviour
+                if (camera.gameObject.GetComponent<CustomCamera>() == null)
+                {
+                    camera.gameObject.AddComponent<CustomCamera>();
+                }
+            }
         }
     }
 }

--- a/External Renderer/Assets/Scripts/PathManagement/DirectoryManager.cs
+++ b/External Renderer/Assets/Scripts/PathManagement/DirectoryManager.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace ExternalUnityRendering.PathManagement
 {
     // TODO see notes in FileManager.cs. Consider same for this.
-    class DirectoryManager
+    public class DirectoryManager
     {
         private DirectoryInfo _directory;
         private bool _createNewDirectory = false;

--- a/Physics/Assets/Editor/ExportGUI.cs
+++ b/Physics/Assets/Editor/ExportGUI.cs
@@ -7,16 +7,26 @@ namespace ExternalUnityRendering.UnityEditor
     [CustomEditor(typeof(ExportScene))]
     public class ExportGUI : Editor
     {
+        private string _exportFolder = "";
         public override void OnInspectorGUI()
         {
             DrawDefaultInspector();
 
-            EditorGUILayout.HelpBox("Click Export Now to export now.", MessageType.None);
-
+            // maybe add a filename detection?
+            EditorGUILayout.HelpBox("Enter the folder to export to below.", MessageType.None);
+            _exportFolder = GUILayout.TextField(_exportFolder);
             ExportScene currentExporter = target as ExportScene;
             if (GUILayout.Button("Export Now"))
             {
-                currentExporter.ExportCurrentScene(ExportScene.ExportType.WriteToFile);
+                currentExporter.ExportFolder = _exportFolder;
+
+                if (currentExporter.ExportFolder == Application.persistentDataPath)
+                {
+                    Debug.LogError("Invalid render folder given.");
+                } else
+                {
+                    currentExporter.ExportCurrentScene(ExportScene.ExportType.WriteToFile, true);
+                }
             }
         }
     }

--- a/Physics/Assets/Scenes/Main.unity
+++ b/Physics/Assets/Scenes/Main.unity
@@ -566,6 +566,80 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &913856850
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 913856852}
+  - component: {fileID: 913856851}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &913856851
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 913856850}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &913856852
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 913856850}
+  m_LocalRotation: {x: -0, y: -0.9628023, z: -0, w: 0.27020684}
+  m_LocalPosition: {x: 2.4, y: 0.65, z: 3.07}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: -148.647, z: 0}
 --- !u!1 &977114813
 GameObject:
   m_ObjectHideFlags: 0
@@ -847,7 +921,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1 &1250538404
 GameObject:
@@ -1051,7 +1125,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1788036832}
   - component: {fileID: 1788036831}
-  - component: {fileID: 1788036830}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1059,14 +1132,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!81 &1788036830
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1788036829}
-  m_Enabled: 1
 --- !u!20 &1788036831
 Camera:
   m_ObjectHideFlags: 0
@@ -1161,7 +1226,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8252001624201780488, guid: 88de24aa742652f4d91ab7f17086eae4, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8252001624201780488, guid: 88de24aa742652f4d91ab7f17086eae4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Physics/Assets/Scripts/ExportScene.cs
+++ b/Physics/Assets/Scripts/ExportScene.cs
@@ -11,6 +11,7 @@ namespace ExternalUnityRendering
     public class ExportScene : MonoBehaviour
     {
         // Currently being used for testing write to file functionality only
+        // May be kept or improved
         public enum ExportType
         {
             Transmit,
@@ -32,7 +33,7 @@ namespace ExternalUnityRendering
             }
         }
 
-        private void Start()
+        private void Awake()
         {
             _exportFolder = new DirectoryManager();
         }
@@ -40,12 +41,12 @@ namespace ExternalUnityRendering
         private void WriteStateToFile(string state)
         {
             FileManager file = new FileManager(_exportFolder, 
-                $"Physics State-{ DateTime.Now:yyyy-MM-dd-HH-mm-ss-fff-UTCzz}.json");
+                $"Physics State-{ DateTime.Now:yyyy-MM-dd-HH-mm-ss-UTCzz}.json", true);
             file.WriteToFile(state);
         }
 
         // HACK functionality and structure needs to be reworked
-        public void ExportCurrentScene(ExportType exportMode = ExportType.Transmit)
+        public void ExportCurrentScene(ExportType exportMode = ExportType.Transmit, bool prettyPrint = false)
         {
             // pauses the state of the Unity
             Time.timeScale = 0; 
@@ -71,7 +72,9 @@ namespace ExternalUnityRendering
 
             Debug.Log("Exporting...");
             SceneState scene = new SceneState(transform);
-            string state = JsonConvert.SerializeObject(scene, Formatting.Indented);
+
+            Formatting jsonFormat = prettyPrint ? Formatting.Indented : Formatting.None;
+            string state = JsonConvert.SerializeObject(scene, jsonFormat);
 
             if (exportMode == ExportType.Transmit || exportMode == ExportType.Both)
             {

--- a/Physics/Assets/Scripts/PathManagement/DirectoryManager.cs
+++ b/Physics/Assets/Scripts/PathManagement/DirectoryManager.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace ExternalUnityRendering.PathManagement
 {
     // TODO see notes in FileManager.cs. Consider same for this.
-    class DirectoryManager
+    public class DirectoryManager
     {
         private DirectoryInfo _directory;
         private bool _createNewDirectory = false;


### PR DESCRIPTION
List of changes/improvements:

- Added text inputs for paths in Unity Editor Inspector view for Importer and Exporter.
- Temporarily removed Importer Menu Item functionality until method of user input for file paths can be implemented.
- Added second camera to Demo Unity Scene.
- Changed render paths such that each camera saves renders to named subdirectories (extensions needed).
- Marked static camera method that formerly attached custom camera components to `GameObjects` with camera as obsolete. Its functionality will be handled during import (and testing/debug methods for exporter).
- Marked Path Management classes as public so that they can be used from editor functions.
- Added option to choose whether `FileManager` instances will create new files if the requested file exists, or to access an existing file (for importer file reading).
- Removed the import file path as a field/method of the `ImportScene` class. Changed method that accessed it to require it as a parameter instead.
- Changed some `MonoBehaviour` classes to initialize in `Awake()` instead of `Start()`, as `Start()` may be called multiple times and reset some data.
- Added setting to toggle JSON pretty printing.

To be rebased after #15 is merged. 

This closes #17.