### PR TITLE
Refactoring fixes

### DIFF
--- a/External Unity Rendering/Assets/Editor/ExporterEditorMenu.cs
+++ b/External Unity Rendering/Assets/Editor/ExporterEditorMenu.cs
@@ -415,7 +415,7 @@ namespace ExternalUnityRendering.UnityEditor
             }
 
                 export.ExportCurrentScene(_exportType, _rendererOutputResolution,
-                    _rendererOutputFolder, true);
+                    _rendererOutputFolder);
 
                 // should do nothing if customcameras empty
                 foreach (CustomCamera cam in customCameras)

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Camera/CustomCamera.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Camera/CustomCamera.cs
@@ -1,6 +1,8 @@
-﻿using ExternalUnityRendering.PathManagement;
-using System;
+﻿using System;
 using System.IO;
+
+using ExternalUnityRendering.PathManagement;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering.CameraUtilites

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/CommandLineParsing/ExporterArguments.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/CommandLineParsing/ExporterArguments.cs
@@ -1,7 +1,10 @@
 using System.Linq;
 using System.Net;
+
 using CommandLine;
+
 using ExternalUnityRendering.PathManagement;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/CommandLineParsing/ImporterArguments.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/CommandLineParsing/ImporterArguments.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using System.Net;
+
 using CommandLine;
+
 using ExternalUnityRendering.PathManagement;
 
 namespace ExternalUnityRendering

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/IP Transmission/Client.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/IP Transmission/Client.cs
@@ -61,42 +61,6 @@ namespace ExternalUnityRendering.TcpIp
         }
 
         /// <summary>
-        /// Create a client to manage sending data to a server over a socket.
-        /// </summary>
-        /// <param name="port">The port to send data to.</param>
-        /// <param name="ipString">The IP address to send data to.</param>
-        /// <param name="maxRetries">The maximum number of times to retry sending data
-        /// after the connection has been refused.</param>
-        public Client(int port, string ipAddr, int maxRetries = 3, int chunkSize = 1024)
-        {
-            try
-            {
-                IPAddress ipAddress = null;
-                if (ipAddr == "localhost")
-                {
-                    ipAddress = IPAddress.Loopback;
-                }
-                else
-                {
-                    ipAddress = IPAddress.Parse(ipAddr);
-                }
-                IPEndPoint remoteEndPoint = new IPEndPoint(ipAddress, port);
-
-                Task.Run(() => SendAsync(remoteEndPoint, maxRetries, chunkSize));
-            }
-            catch (SocketException se)
-            {
-                Debug.LogError("An error occured while trying to initialise the socket. " +
-                    $"The error code is {se.SocketErrorCode}.\n{se}");
-            }
-            catch (ArgumentException ae)
-            {
-                Debug.LogError("An error occurred while trying to resolve the host. " +
-                    $"\n{ae}");
-            }
-        }
-
-        /// <summary>
         /// Read messages from the queue and transmit them to <paramref name="remoteEndPoint"/>.
         /// </summary>
         /// <param name="remoteEndPoint">The remote endpoint to send data to.</param>
@@ -214,6 +178,42 @@ namespace ExternalUnityRendering.TcpIp
             }
 
             _completedTransmission.Set();
+        }
+
+        /// <summary>
+        /// Create a client to manage sending data to a server over a socket.
+        /// </summary>
+        /// <param name="port">The port to send data to.</param>
+        /// <param name="ipString">The IP address to send data to.</param>
+        /// <param name="maxRetries">The maximum number of times to retry sending data
+        /// after the connection has been refused.</param>
+        public Client(int port, string ipAddr, int maxRetries = 3, int chunkSize = 1024)
+        {
+            try
+            {
+                IPAddress ipAddress = null;
+                if (ipAddr == "localhost")
+                {
+                    ipAddress = IPAddress.Loopback;
+                }
+                else
+                {
+                    ipAddress = IPAddress.Parse(ipAddr);
+                }
+                IPEndPoint remoteEndPoint = new IPEndPoint(ipAddress, port);
+
+                Task.Run(() => SendAsync(remoteEndPoint, maxRetries, chunkSize));
+            }
+            catch (SocketException se)
+            {
+                Debug.LogError("An error occured while trying to initialise the socket. " +
+                    $"The error code is {se.SocketErrorCode}.\n{se}");
+            }
+            catch (ArgumentException ae)
+            {
+                Debug.LogError("An error occurred while trying to resolve the host. " +
+                    $"\n{ae}");
+            }
         }
 
         /// <summary>

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/IP Transmission/Client.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/IP Transmission/Client.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 using ExternalUnityRendering.Serialization;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering.TcpIp

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/IP Transmission/Server.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/IP Transmission/Server.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -122,7 +121,7 @@ namespace ExternalUnityRendering.TcpIp
             Socket handler;
             bool successfulReceipt = false;
             byte[] cache = new byte[1024];
-            ArraySegment<byte> segmentCache = new ArraySegment<byte>(new byte[1024]);
+            ArraySegment<byte> segmentCache = new ArraySegment<byte>(cache);
 
             using (MemoryStream ms = new MemoryStream())
             while (true)
@@ -140,7 +139,14 @@ namespace ExternalUnityRendering.TcpIp
                         await ms.WriteAsync(cache, 0, bytesReceived);
                     } while (!(handler.Poll(1, SelectMode.SelectRead) && handler.Available == 0));
 
-                    Debug.Log($"Read {totalBytesReceived} bytes from {handler.RemoteEndPoint} at {DateTime.Now}.");
+                    if (totalBytesReceived == 0)
+                    {
+                        Debug.Log("Empty string received.");
+                        continue;
+                    }
+
+                    Debug.Log($"Read {totalBytesReceived} bytes from {handler.RemoteEndPoint} at " +
+                        $"{DateTime.Now}.");
                     successfulReceipt = true;
                 }
                 catch (SocketException se)

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/IP Transmission/Server.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/IP Transmission/Server.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering.TcpIp

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/InitializeEUR.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/InitializeEUR.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+
 using CommandLine;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/PathManagement/DirectoryManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/PathManagement/DirectoryManager.cs
@@ -139,5 +139,16 @@ namespace ExternalUnityRendering.PathManagement
         public DirectoryManager(DirectoryManager directory, string directoryName,
             bool createNew = false)
             : this(System.IO.Path.Combine(directory.Path, directoryName), createNew) { }
+
+        /// <summary>
+        /// Create a subdirectory in <paramref name="parentDirectory"/> named
+        /// <paramref name="directoryName"/>.
+        /// </summary>
+        /// <param name="parentDirectory">The main directory in which to create the subfolder.</param>
+        /// <param name="directoryName">The name of the subdirectory.</param>
+        /// <param name="createNew">Whether the folder should be unique.</param>
+        public DirectoryManager(string parentDirectory, string directoryName,
+            bool createNew = false)
+            : this(System.IO.Path.Combine(parentDirectory, directoryName), createNew) { }
     }
 }

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/PathManagement/DirectoryManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/PathManagement/DirectoryManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering.PathManagement

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/PathManagement/FileManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/PathManagement/FileManager.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering.PathManagement

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/PathManagement/FileManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/PathManagement/FileManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace ExternalUnityRendering.PathManagement
@@ -12,15 +13,7 @@ namespace ExternalUnityRendering.PathManagement
     /// </summary>
     public class FileManager
     {
-        /// <summary>
-        /// Internal reference to the file that this object manages.
-        /// </summary>
-        private FileInfo _file;
-
-        /// <summary>
-        /// Whether this file must be unique. Will automatically rename the
-        /// </summary>
-        private readonly bool _createNew = false;
+        private string _filePath = null;
 
         /// <summary>
         /// The path of the file that this instance manages. It will not assign invalid paths.
@@ -29,68 +22,119 @@ namespace ExternalUnityRendering.PathManagement
         {
             get
             {
-                return _file?.FullName;
+                return _filePath;
             }
             set
             {
+                SavePath(value, false);
+            }
+        }
+
+        private void SavePath(string path, bool createNew)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            try
+            {
+                string fullPath = System.IO.Path.GetFullPath(path);
+                string dirName = System.IO.Path.GetDirectoryName(fullPath);
+
+                if (Directory.Exists(fullPath) || (File.Exists(fullPath) && createNew))
+                {
+                    int i = 1;
+                    string nameWithoutExtension =
+                        System.IO.Path.GetFileNameWithoutExtension(fullPath);
+                    string extension = System.IO.Path.GetExtension(fullPath);
+
+                    do
+                    {
+                        // rename as file (1).ext, file (2).ext and so on and so forth
+                        fullPath =
+                            System.IO.Path.GetFullPath(System.IO.Path.Combine(dirName,
+                                $"{nameWithoutExtension} ({i++}){extension}"));
+                    } while (File.Exists(fullPath));
+                }
+
+                if (!Directory.Exists(dirName))
+                {
+                    Directory.CreateDirectory(dirName);
+                }
+
+                if (!File.Exists(fullPath))
+                {
+                    File.Create(fullPath).Close();
+                }
+
+                _filePath = fullPath;
+            }
+            catch (ArgumentException ae)
+            {
+                Debug.LogError($"The file path \"{path}\" is empty or contains invalid " +
+                    $"characters.\n{ae}");
+            }
+            catch (System.Security.SecurityException se)
+            {
+                Debug.LogError("You do not have the permissions to access "
+                    + $"\"{ path }\".\n{ se }");
+            }
+            catch (UnauthorizedAccessException uae)
+            {
+                Debug.LogError($"Access to \"{ path }\" is denied.\n{ uae }");
+            }
+            catch (PathTooLongException ptle)
+            {
+                Debug.LogError($"The path \"{ path }\" is too long.\n{ ptle }");
+                // Retry with extended filename for windows
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
                 try
                 {
-                    FileInfo file = new FileInfo(value);
-                    if (file.Exists)
+                    string winPath = $@"\\?\{System.IO.Path.GetFullPath(path).Replace('/', '\\')}";
+                    System.IO.Path.GetFullPath(winPath);
+                    string dirName = System.IO.Path.GetDirectoryName(winPath);
+                    if (Directory.Exists(winPath) || (File.Exists(winPath) && createNew))
                     {
-                        if (!_createNew)
-                        {
-                            _file = file;
-                            return;
-                        }
                         int i = 1;
                         string nameWithoutExtension =
-                            System.IO.Path.GetFileNameWithoutExtension(file.FullName);
-                        string extension = file.Extension;
-                        string filename = "";
+                            System.IO.Path.GetFileNameWithoutExtension(winPath);
+                        string extension = System.IO.Path.GetExtension(winPath);
 
                         do
                         {
-                            // Rename in the same way windows does.
-                            filename = $"{nameWithoutExtension} ({i++}){extension}";
-                        } while (File.Exists(filename));
-
-                        file = new FileInfo(filename);
+                            // rename as file (1).ext, file (2).ext and so on and so forth
+                            winPath =
+                                System.IO.Path.GetFullPath(System.IO.Path.Combine(dirName,
+                                    $"{ nameWithoutExtension} ({i++}){extension}"));
+                        } while (File.Exists(winPath));
                     }
-                    file.Create().Close();
-                    _file = file;
+
+                    if (!Directory.Exists(dirName))
+                    {
+                        Directory.CreateDirectory(dirName);
+                    }
+
+                    if (!File.Exists(winPath))
+                    {
+                        File.Create(winPath).Close();
+                    }
+
+                    _filePath = winPath;
+                    Debug.Log($"Created folder using windows extended path syntax: {winPath}");
+                    return;
                 }
-                catch (ArgumentNullException ane)
-                {
-                    Debug.LogError($"Cannot set file path to null.\n{ ane }");
-                }
-                catch (ArgumentException ae)
-                {
-                    Debug.LogError($"The folder <{ value }> is empty or contains "
-                        + $"invalid characters.\n{ ae }");
-                }
-                catch (System.Security.SecurityException se)
-                {
-                    Debug.LogError("You do not have the permissions to access "
-                        + $"<{ value }>.\n{ se }");
-                }
-                catch (UnauthorizedAccessException uae)
-                {
-                    Debug.LogError($"Access to <{ value }> is denied.\n{ uae }");
-                }
-                catch (PathTooLongException ptle)
-                {
-                    // TODO: Implement retry with extended filename for windows
-                    Debug.LogError($"The path <{ value }> is too long.\n{ ptle }");
-                }
-                catch (NotSupportedException nse)
-                {
-                    Debug.LogError($"The path <{ value }> contains a colon.\n{ nse }");
-                }
-                catch (IOException ioe)
-                {
-                    Debug.LogError($"The file <{ value }> could not be created.\n{ ioe }");
-                }
+                // If failed in any way, do nothing.
+                catch { }
+#endif
+            }
+            catch (NotSupportedException nse)
+            {
+                Debug.LogError($"The path \"{path}\" contains a colon.\n{nse}");
+            }
+            catch (IOException ioe)
+            {
+                Debug.LogError($"The file \"{path}\" could not be created.\n{ioe}");
             }
         }
 
@@ -98,24 +142,9 @@ namespace ExternalUnityRendering.PathManagement
         /// Generate a file that should be unique. To be used as a fallback for files that must exist.
         /// </summary>
         public FileManager()
-        {
-            // HACK assumes no exceptions rn because if it does,
-            // its likely a pathtoolong exception this is an edge case though
-            // consider options
-            // Create a near-guaranteed valid and unique file. See the first
-            // comment on https://stackoverflow.com/a/11938280
-            FileInfo file = new FileInfo(
-                System.IO.Path.Combine(Application.persistentDataPath,
-                (
-                    DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss-fff-UTCzz")
-                    + $" { Guid.NewGuid() }.dat"
-                )));
+            : this(System.IO.Path.Combine(Application.persistentDataPath,
+                System.IO.Path.GetRandomFileName()), false) { }
 
-            file.Create().Close();
-            _file = file;
-        }
-
-        // HACK Tries to detect if path is relative (a filename) or absolute
         /// <summary>
         /// Creates a file given a path as a string.
         /// </summary>
@@ -123,22 +152,7 @@ namespace ExternalUnityRendering.PathManagement
         /// <param name="createNew">Whether the file must be newly created.</param>
         public FileManager(string path, bool createNew = false)
         {
-            // note, this does implement the some of the same functionality another
-            // constructor but I can't call it from here without some funky obfuscated
-            // logic that may perform worse
-            _createNew = createNew;
-            // check if file path is absolute or relative, may not be optimal for windows
-            if (System.IO.Path.IsPathRooted(path))
-            {
-                string directoryPath = System.IO.Path.GetDirectoryName(path);
-                path = path.Remove(0, directoryPath.Length);
-                DirectoryManager directory = new DirectoryManager(directoryPath);
-                Path = System.IO.Path.Combine(directory.Path, path);
-            }
-            else
-            {
-                Path = System.IO.Path.Combine(Application.persistentDataPath, path);
-            }
+            SavePath(path, createNew);
         }
 
         /// <summary>
@@ -148,10 +162,7 @@ namespace ExternalUnityRendering.PathManagement
         /// <param name="name">The name of the file.</param>
         /// <param name="createNew">Whether the file must be newly created.</param>
         public FileManager(DirectoryManager directory, string name, bool createNew = false)
-        {
-            _createNew = createNew;
-            Path = System.IO.Path.Combine(directory.Path, name);
-        }
+            : this(System.IO.Path.Combine(directory.Path, name), createNew) { }
 
         /// <summary>
         /// Create a file given a string folder and filename.
@@ -162,9 +173,6 @@ namespace ExternalUnityRendering.PathManagement
         /// <param name="createNew">Whether the file must be newly created.</param>
         public FileManager(string folder, string name, bool createNew = false)
             : this(new DirectoryManager(folder), name, createNew) { }
-
-        // OPTIONAL add more options based on the overloads for writer, use generics maybe?
-        // OPTIONAL retry options?
 
         /// <summary>
         /// Write string into file and return its success.
@@ -179,10 +187,69 @@ namespace ExternalUnityRendering.PathManagement
 
             try
             {
-                using (FileStream stream = _file.Open(mode))
+                using (FileStream stream = File.Open(_filePath, mode, FileAccess.Write,
+                    FileShare.Read))
                 using (StreamWriter writer = new StreamWriter(stream))
                 {
                     writer.WriteLine(data);
+                }
+                return true;
+            }
+            catch (FileNotFoundException fnfe)
+            {
+                Debug.LogError($"The file has not been found.\n{ fnfe }");
+            }
+            catch (DirectoryNotFoundException dnfe)
+            {
+                // Constructor enforces a valid directory, so this error must be due
+                // to some sort of lock or deletion
+                Debug.LogError($"The file directory may have been deleted.\n{ dnfe }");
+            }
+            catch (System.Security.SecurityException se)
+            {
+                Debug.LogError($"The caller does not have the required permission.\n{ se }");
+            }
+            catch (UnauthorizedAccessException uae)
+            {
+                Debug.LogError($"Name is read-only.\n{ uae }");
+            }
+            catch (ObjectDisposedException ode)
+            {
+                Debug.LogError("The StreamWriter buffer may be full, and current writer " +
+                    $"is closed.\n{ ode }");
+            }
+            catch (NotSupportedException nse)
+            {
+                Debug.LogError("The StreamWriter buffer may full, and the contents of the " +
+                    "buffer cannot be written to the underlying fixed size stream because " +
+                    $"the StreamWriter is at the end the stream.\n{ nse }");
+            }
+            catch (IOException ioe)
+            {
+                Debug.LogError("The file is already opened by another process or an I/O " +
+                    $"error has occurred while writing to file.\n{ ioe }");
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Write string into file and return its success.
+        /// </summary>
+        /// <param name="data">The string to be written to file.</param>
+        /// <param name="append">False if to overwrite the file's contents,
+        /// true to append <paramref name="data"/> to the end of the file.</param>
+        /// <returns>True if the data was written sucessfully.</returns>
+        public async Task<bool> WriteToFileAsync(string data, bool append = false)
+        {
+            FileMode mode = append ? FileMode.Append : FileMode.Truncate;
+
+            try
+            {
+                using (FileStream stream = File.Open(_filePath, mode, FileAccess.Write,
+                    FileShare.Read))
+                using (StreamWriter writer = new StreamWriter(stream))
+                {
+                    await writer.WriteAsync(data);
                 }
                 return true;
             }
@@ -237,9 +304,68 @@ namespace ExternalUnityRendering.PathManagement
 
             try
             {
-                using (FileStream stream = _file.OpenWrite())
+                using (FileStream stream = File.OpenWrite(_filePath))
                 {
                     stream.Write(data, 0, data.Length);
+                }
+            }
+            catch (UnauthorizedAccessException uae)
+            {
+                Debug.LogError($"Name is read-only.\n{ uae }");
+            }
+            catch (DirectoryNotFoundException dnfe)
+            {
+                // Constructor enforces a valid directory, so this error must be due
+                // to some sort of lock or deletion
+                Debug.LogError($"The file directory may have been deleted.\n{ dnfe }");
+            }
+            catch (ArgumentOutOfRangeException aoore)
+            {
+                // normally would trigger when the second and/or third params to
+                // stream.Write are negative, but that **should** not be possible.
+                // Multithreading issue??
+                Debug.LogError($"Could not write data in array to stream.\n{ aoore }");
+            }
+            catch (ArgumentException ae)
+            {
+                // same as above but with generally invalid values e.g outside range of array
+                Debug.LogError($"Could not write data in array to stream.\n{ ae }");
+            }
+            catch (ObjectDisposedException ode)
+            {
+                Debug.LogError($"The stream is closed.\n{ ode }");
+            }
+            catch (NotSupportedException nse)
+            {
+                Debug.LogError("The StreamWriter buffer may full, and the contents of the " +
+                    "buffer cannot be written to the underlying fixed size stream because " +
+                    $"the StreamWriter is at the end the stream.\n{ nse }");
+            }
+            catch (IOException ioe)
+            {
+                Debug.LogError("An I/O error occurred or another thread may have caused " +
+                    "an unexpected change in the position of the operating system's file " +
+                    $"handle.\n{ ioe }");
+            }
+        }
+
+        /// <summary>
+        /// Write <paramref name="data"/> to file as bytes.
+        /// </summary>
+        /// <param name="data">THe byte data to write.</param>
+        public async void WriteToFileAsync(byte[] data)
+        {
+            if (data == null)
+            {
+                Debug.LogError("Cannot write a null array to disk.");
+                return;
+            }
+
+            try
+            {
+                using (FileStream stream = File.OpenWrite(_filePath))
+                {
+                    await stream.WriteAsync(data, 0, data.Length);
                 }
             }
             catch (UnauthorizedAccessException uae)
@@ -292,7 +418,7 @@ namespace ExternalUnityRendering.PathManagement
             StringBuilder data = new StringBuilder();
             try
             {
-                using (FileStream stream = _file.OpenRead())
+                using (FileStream stream = File.OpenRead(_filePath))
                 using (StreamReader reader = new StreamReader(stream))
                 {
                     data.Append(reader.ReadToEnd());
@@ -317,17 +443,43 @@ namespace ExternalUnityRendering.PathManagement
                 Debug.LogError("The file is already open or an I/O error has occured." +
                     $"\n{ ioe }");
             }
-            catch (OutOfMemoryException oome)
+
+            return data.ToString();
+        }
+
+        /// <summary>
+        /// Asynchronously reads from the file and returns the data as a string.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> that resolves when the data has been read. </returns>
+        public async Task<string> ReadFileAsync()
+        {
+            StringBuilder data = new StringBuilder();
+            try
             {
-                // log but don't handle. Unity **should** handle this appropriately
-                // The following link (split in two)
-                // https://docs.microsoft.com/en-us/dotnet/api/system.outofmemoryexception?
-                // view=net-5.0#:~:text=This%20type%20of%20OutOfMemoryException,example%20does.
-                // says that Environment.FailFast() should be called, but unity should do that
-                // if unity doesn't do it well ¯\_(ツ)_/¯
-                Debug.LogError("Catastrophic error. Out of memory when trying to " +
-                    $"read from { _file.FullName }.\n{ oome }");
-                throw;
+                using (FileStream stream = File.OpenRead(_filePath))
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    data.Append(await reader.ReadToEndAsync());
+                }
+            }
+            catch (UnauthorizedAccessException uae)
+            {
+                Debug.LogError($"Name is read-only.\n{ uae }");
+            }
+            catch (DirectoryNotFoundException dnfe)
+            {
+                // Constructor enforces a valid directory, so this error must be due
+                // to some sort of lock or deletion
+                Debug.LogError($"The file directory may have been deleted.\n{ dnfe }");
+            }
+            catch (ArgumentException ae)
+            {
+                Debug.LogError($"The stream does not support reading.\n{ ae }");
+            }
+            catch (IOException ioe)
+            {
+                Debug.LogError("The file is already open or an I/O error has occured." +
+                    $"\n{ ioe }");
             }
 
             return data.ToString();

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/Exporter.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/Exporter.cs
@@ -7,6 +7,7 @@ using ExternalUnityRendering.Serialization;
 using ExternalUnityRendering.TcpIp;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 using UnityEngine;
@@ -58,7 +59,6 @@ namespace ExternalUnityRendering
         {
             get
             {
-                // TODO fix possible null reference exception
                 return _exportFolder.Path;
             }
             set
@@ -85,15 +85,30 @@ namespace ExternalUnityRendering
         public Client Sender = null;
 
         /// <summary>
+        /// Singleton for this <see cref="Exporter"/>.
+        /// </summary>
+        private static Exporter s_instance = null;
+
+        /// <summary>
         /// Early initialization of the Exporter.
         /// </summary>
         private void Awake()
         {
+            if (s_instance != null && s_instance != this)
+            {
+                Debug.LogError($"Cannot have more than one {nameof(Exporter)} in the scene.");
+                Destroy(this);
+                return;
+            }
+            s_instance = this;
+
             _exportFolder = new DirectoryManager();
+
             _exportActions = new Dictionary<PostExportAction, Func<string, bool>>()
             {
-                {PostExportAction.Nothing, (state) => { return true; } },
-                {PostExportAction.Transmit, (state) => Sender.Send(state) },
+                // Minify the json for transmitting
+                {PostExportAction.Transmit, (state) =>
+                    Sender.Send(JToken.Parse(state).ToString(Formatting.None)) },
                 {PostExportAction.WriteToFile, (state) => WriteStateToFile(state) },
                 {PostExportAction.Log, (state) => { Debug.Log($"JSON Data = { state }"); return true; } },
             };
@@ -110,6 +125,7 @@ namespace ExternalUnityRendering
 
             _serializer.Converters.Add(new EURGameObjectConverter());
             _serializer.Converters.Add(new EURSceneConverter());
+            _serializer.Formatting = Formatting.Indented;
         }
 
         /// <summary>
@@ -154,8 +170,7 @@ namespace ExternalUnityRendering
         /// <param name="prettyPrint">Whether to format the JSON to be more human
         /// readable.</param>
         public void ExportCurrentScene(PostExportAction exportMode,
-            Vector2Int renderResolution = default, string renderDirectory = "",
-            bool prettyPrint = false)
+            Vector2Int renderResolution = default, string renderDirectory = "")
         {
             // ensure this gameobject is a root object.
             transform.parent = null;
@@ -192,7 +207,7 @@ namespace ExternalUnityRendering
 
             Task.Run(() =>
             {
-                SerializeAndExport(scene, exportMode, prettyPrint);
+                SerializeAndExport(scene, exportMode);
             });
 
             // unparent all gameobject so that exporting can be preformed
@@ -212,12 +227,10 @@ namespace ExternalUnityRendering
         /// <param name="exportMode">The Export Actions to perform. The flags will be searched in
         /// <see cref="_exportActions"/> for the appropriate actions. </param>
         /// <param name="prettyPrint">Whether to format the json.</param>
-        private void SerializeAndExport(EURScene scene, PostExportAction exportMode, bool prettyPrint)
+        private void SerializeAndExport(EURScene scene, PostExportAction exportMode)
         {
             try
             {
-                _serializer.Formatting = prettyPrint ? Formatting.Indented : Formatting.None;
-
                 bool succeeded = true;
                 _serializer.Error += delegate (object sender, ErrorEventArgs args)
                 {
@@ -231,24 +244,29 @@ namespace ExternalUnityRendering
                     _serializer.Serialize(writer, scene);
                 }
 
-                string state = sb.ToString();
 
-                if (!succeeded || state == null)
+
+                if (!succeeded)
                 {
                     Debug.Log("Aborting Export. Failed to serialize. Check logs for cause.");
                     return;
                 }
 
+                if (exportMode == PostExportAction.Nothing)
+                {
+                    Debug.Log("No export action was specified. Serialization completed " +
+                        "successfully.");
+                    return;
+                }
+
+                string state = sb.ToString();
+
                 foreach (KeyValuePair<PostExportAction, Func<string, bool>> item in _exportActions)
                 {
-                    if ((item.Key & exportMode) == item.Key)
+                    if (exportMode.HasFlag(item.Key))
                     {
                         bool success = item.Value.Invoke(state);
-                        if (item.Key == PostExportAction.Nothing)
-                        {
-                            continue;
-                        }
-                        if ((item.Key & exportMode) == PostExportAction.Transmit)
+                        if (item.Key == PostExportAction.Transmit)
                         {
                             Debug.Log("Queued Data to be transmitted. See logs for status.");
                         }

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/Exporter.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/Exporter.cs
@@ -93,7 +93,7 @@ namespace ExternalUnityRendering
             _exportActions = new Dictionary<PostExportAction, Func<string, bool>>()
             {
                 {PostExportAction.Nothing, (state) => { return true; } },
-                {PostExportAction.Transmit, (state) => Sender.QueueSend(state) },
+                {PostExportAction.Transmit, (state) => Sender.Send(state) },
                 {PostExportAction.WriteToFile, (state) => WriteStateToFile(state) },
                 {PostExportAction.Log, (state) => { Debug.Log($"JSON Data = { state }"); return true; } },
             };

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/ExporterManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/ExporterManager.cs
@@ -65,7 +65,7 @@ namespace ExternalUnityRendering
         /// <param name="exporter">The exporter to export the current scene with.</param>
         /// <returns>IEnumerator to use for <see cref="MonoBehaviour.StartCoroutine(IEnumerator)"/>.
         /// </returns>
-        IEnumerator ExportLoop(Exporter exporter)
+        private IEnumerator ExportLoop(Exporter exporter)
         {
             exporter.ExportFolder = Arguments.JsonPath;
             float delaySeconds = Arguments.MillisecondsDelay / 1000f;

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/ExporterManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/ExporterManager.cs
@@ -84,11 +84,11 @@ namespace ExternalUnityRendering
                 Debug.Log("Emptied queue and sending closing message.");
                 if (Application.isBatchMode)
                 {
-                    exporter.Sender.FinishTransmissionsAndClose();
+                    exporter.Sender.Close();
                 }
                 else
                 {
-                    yield return new WaitUntil(exporter.Sender.IsDone);
+                    yield return new WaitUntil(() => exporter.Sender.IsDone);
                 }
             }
 
@@ -112,10 +112,10 @@ namespace ExternalUnityRendering
             Exporter exporter = FindObjectOfType<Exporter>();
             if (exporter != null
                 && Arguments.ExportActions.HasFlag(Exporter.PostExportAction.Transmit)
-                && !exporter.Sender.IsDone())
+                && !exporter.Sender.IsDone)
             {
                 Debug.Log("Waiting for exporter to close.");
-                exporter.Sender.FinishTransmissionsAndClose();
+                exporter.Sender.Close();
             }
         }
     }

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/ExporterManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/ExporterManager.cs
@@ -8,7 +8,7 @@ namespace ExternalUnityRendering
         /// <summary>
         /// The singleton representing the current <see cref="ExporterManager"/>.
         /// </summary>
-        private static ExporterManager _instance = null;
+        private static ExporterManager s_instance = null;
 
         /// <summary>
         /// The <see cref="ExporterArguments"/> for this manager.
@@ -27,14 +27,14 @@ namespace ExternalUnityRendering
             return;
 #endif
 #pragma warning disable CS0162 // unreachable code warning when UNITY_EDITOR is set
-            if (_instance != null && _instance != this)
+            if (s_instance != null && s_instance != this)
             {
                 Debug.LogError($"Cannot have multiple instances of {nameof(ExporterManager)}");
                 Destroy(this);
                 return;
             }
 
-            _instance = this;
+            s_instance = this;
 #pragma warning restore
         }
 

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/ExporterManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Physics/ExporterManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Renderer/Importer.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Renderer/Importer.cs
@@ -19,17 +19,26 @@ namespace ExternalUnityRendering
     /// </summary>
     public class Importer : MonoBehaviour
     {
-#if UNITY_EDITOR
+        private static Importer s_instance = null;
         /// <summary>
-        /// Initialise a receiver if in editor
+        /// Initialise a receiver.
         /// </summary>
         private void Awake()
         {
-            Debug.LogWarning("Improperly implemented automatic setup for editor");
+            if (s_instance != null && s_instance != this)
+            {
+                Debug.LogError($"Cannot have more than one {nameof(Importer)} in the scene.");
+                Destroy(this);
+                return;
+            }
+            s_instance = this;
+
+#if UNITY_EDITOR
+            Debug.LogWarning("Improperly implemented automatic setup for editor.");
             new Server(11000, "localhost").ProcessCallbackAsync((state) => ImportCurrentScene(state));
             Debug.Log("Awaiting Messages?");
-        }
 #endif
+        }
 
         /// <summary>
         /// Import data from a file.

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Renderer/ImporterManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Renderer/ImporterManager.cs
@@ -1,4 +1,5 @@
 ﻿using ExternalUnityRendering.TcpIp;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Renderer/ImporterManager.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Renderer/ImporterManager.cs
@@ -11,7 +11,7 @@ namespace ExternalUnityRendering
         /// <summary>
         /// Singleton representing the current <see cref="ImporterManager"/>.
         /// </summary>
-        private static ImporterManager _instance = null;
+        private static ImporterManager s_instance = null;
 
         /// <summary>
         /// The <see cref="ImporterArguments"/> for this manager.
@@ -28,13 +28,13 @@ namespace ExternalUnityRendering
             return;
 #endif
 #pragma warning disable CS0162 // unreachable code warning when UNITY_EDITOR is set
-            if (_instance != null && _instance != this)
+            if (s_instance != null && s_instance != this)
             {
                 Debug.LogError("Cannot have multiple instances of RendererImportManager.");
                 Destroy(this);
                 return;
             }
-            _instance = this;
+            s_instance = this;
 #pragma warning restore
         }
 

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURGameObject.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURGameObject.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using UnityEngine;
+
 using Newtonsoft.Json;
 
 namespace ExternalUnityRendering.Serialization

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURGameObjectConverter.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURGameObjectConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.UnityConverters;
 using Newtonsoft.Json.UnityConverters.Math;

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURScene.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURScene.cs
@@ -13,6 +13,22 @@ namespace ExternalUnityRendering.Serialization
     public class EURScene
     {
         /// <summary>
+        /// An empty serialized scene with <see cref="ContinueImporting"/> set to false.
+        /// </summary>
+        [JsonIgnore]
+        public static string ClosingMessage
+        {
+            get
+            {
+                EURScene closingMessage = new EURScene
+                {
+                    ContinueImporting = false
+                };
+                return JsonConvert.SerializeObject(closingMessage);
+            }
+        }
+
+        /// <summary>
         /// Struct that represents settings for a <see cref="CameraUtilites.CustomCamera"/>
         /// </summary>
         public struct CameraSettings

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURScene.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURScene.cs
@@ -18,17 +18,11 @@ namespace ExternalUnityRendering.Serialization
         /// An empty serialized scene with <see cref="ContinueImporting"/> set to false.
         /// </summary>
         [JsonIgnore]
-        public static string ClosingMessage
-        {
-            get
-            {
-                EURScene closingMessage = new EURScene
+        public static readonly string ClosingMessage = 
+            JsonConvert.SerializeObject(new EURScene
                 {
                     ContinueImporting = false
-                };
-                return JsonConvert.SerializeObject(closingMessage);
-            }
-        }
+                });
 
         /// <summary>
         /// Struct that represents settings for a <see cref="CameraUtilites.CustomCamera"/>

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURScene.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURScene.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 using UnityEngine;
+
 using Newtonsoft.Json;
 
 namespace ExternalUnityRendering.Serialization

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURSceneConverter.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Serialization/EURSceneConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.UnityConverters;
 using Newtonsoft.Json.UnityConverters.Math;

--- a/External Unity Rendering/Assets/Scripts/External Unity Rendering/Testing Code/ExportTesting.cs
+++ b/External Unity Rendering/Assets/Scripts/External Unity Rendering/Testing Code/ExportTesting.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Linq;
+
 using UnityEngine;
 
 namespace ExternalUnityRendering.TestingCode


### PR DESCRIPTION
To be merged after #38 

Performed the following refactors:
- organised usings, members and methods.
- formatted lines according to a line length of 100 characters.
- switched from ASCII to UTF8 for transmission.
- Renamed Instances and associated classes to Exporter and Importer
- Added option for limiting queue count in awaitableconcurrentqueue
- Renamed Client functions with more appropriate names, and removed unnecessary parameters
- Added non-serialized read only string holding the closing message.
- Add handling for zero length received message.
- Added singleton method for Exporter, ExporterManager, Importer, ImporterManager
- Changed serialization to format with indentation by default, and minify for transmission, and removed pretty print argument
- Refactored Path managers, and moved validation from property to private function
- Removed use of directoryinfo and fileinfo, and used file paths with the static class methods for directory and file manipulation
- Added Async Read and write methods